### PR TITLE
fix: throw on connect if custom nodes disabled 

### DIFF
--- a/imports/startup/server/index.js
+++ b/imports/startup/server/index.js
@@ -2212,6 +2212,13 @@ const ledgerCreateMessageTx = async (sourceAddr, fee, message, cb) => {
 // Define Meteor Methods
 Meteor.methods({
   connectToNode(request) {
+    let { allowCustomNodes } = Meteor.settings
+    if (allowCustomNodes !== true) {
+      allowCustomNodes = false
+    }
+    if (!allowCustomNodes) {
+      throw new Meteor.Error(403, 'Custom node connections are disabled')
+    }
     this.unblock()
     check(request, String)
     const response = Meteor.wrapAsync(connectToNode)(request)


### PR DESCRIPTION
This pull request adds validation to prevent custom node connections unless explicitly allowed in the server settings. If `allowCustomNodes` is not set to `true` in `Meteor.settings`, any attempt to connect to a custom node will result in a 403 error.

Security improvements:

* Added a check in the `connectToNode` Meteor method (in `imports/startup/server/index.js`) to throw a 403 error if `allowCustomNodes` is not enabled in the server settings, preventing unauthorized custom node connections.